### PR TITLE
[Functions] First row Name cell is clipped on expand

### DIFF
--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -265,7 +265,7 @@
           .table-body__row {
             &:first-child {
               position: sticky;
-              top: 45px;
+              top: 35px;
               z-index: 1;
               background-color: $white;
 


### PR DESCRIPTION
https://trello.com/c/1PlEerWA/964-functions-first-row-name-cell-is-clipped-on-expand